### PR TITLE
Fix path regex generation

### DIFF
--- a/convert/oas3.go
+++ b/convert/oas3.go
@@ -640,8 +640,9 @@ func ConvertOas3(content *[]byte, opts O2kOptions) (map[string]interface{}, erro
 
 			// convert path parameters to regex captures
 			re, _ := regexp.Compile("{([^}]+)}")
-			if matches := re.FindAllString(path, -1); matches != nil {
-				for _, varName := range matches {
+			if matches := re.FindAllStringSubmatch(path, -1); matches != nil {
+				for _, match := range matches {
+					varName := match[1]
 					// match single segment; '/', '?', and '#' can mark the end of a segment
 					// see https://github.com/OAI/OpenAPI-Specification/issues/291#issuecomment-316593913
 					regexMatch := "(?<" + varName + ">[^#?/]+)"

--- a/convert/oas3_testfiles/12-path-regex.expected.json
+++ b/convert/oas3_testfiles/12-path-regex.expected.json
@@ -1,0 +1,37 @@
+{
+  "_format_version": "3.0",
+  "services": [
+    {
+      "host": "example.com",
+      "id": "520e4991-2d1a-59b8-bf2e-579cca0969a0",
+      "name": "path-parameter-test",
+      "path": "",
+      "plugins": [],
+      "port": 443,
+      "protocol": "https",
+      "routes": [
+        {
+          "id": "e97557be-3897-52e3-8b56-92b703d3fb73",
+          "methods": [
+            "GET"
+          ],
+          "name": "path-parameter-test_create",
+          "paths": [
+            "~/demo/(?<something>[^#?/]+)/else$"
+          ],
+          "plugins": [],
+          "strip_path": false,
+          "tags": [
+            "OAS3_import",
+            "OAS3file_12-path-regex.yaml"
+          ]
+        }
+      ],
+      "tags": [
+        "OAS3_import",
+        "OAS3file_12-path-regex.yaml"
+      ]
+    }
+  ],
+  "upstreams": []
+}

--- a/convert/oas3_testfiles/12-path-regex.yaml
+++ b/convert/oas3_testfiles/12-path-regex.yaml
@@ -1,0 +1,33 @@
+# The {something} parameter should be converted to a regex
+openapi: 3.0.3
+info:
+  title: Path parameter test
+  version: v1
+servers:
+  - url: "https://example.com"
+
+paths:
+  /demo/{something}/else:
+    get:
+      tags: [demo]
+      operationId: create
+      description: This is a demo OAS
+      parameters:
+        - in: path
+          name: something
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+          description: The user ID
+      responses:
+        "200":
+          description: OK
+          content:
+            "application/json":
+              schema:
+                properties:
+                  status:
+                    type: string
+tags:
+  - name: demo


### PR DESCRIPTION
The regex match didn't work as expected without using `Submatch`:

```
	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -20,3 +20,3 @@
        	            	      (string) (len=5) "paths": ([]interface {}) (len=1) {
        	            	-      (string) (len=34) "~/demo/(?<something>[^#?/]+)/else$"
        	            	+      (string) (len=24) "~/demo/{something}/else$"
```