### PR TITLE
fix(path) ensure valid capture name in path regex

### DIFF
--- a/convertoas3/oas3_testfiles/12-path-parameter-regex.expected.json
+++ b/convertoas3/oas3_testfiles/12-path-parameter-regex.expected.json
@@ -17,7 +17,7 @@
           ],
           "name": "path-parameter-test_opsid",
           "paths": [
-            "~/demo/(?<something>[^#?/]+)/else/(?<todo>[^#?/]+)/$"
+            "~/demo/(?<something>[^#?/]+)/else/(?<to_do>[^#?/]+)/$"
           ],
           "plugins": [],
           "strip_path": false,

--- a/convertoas3/oas3_testfiles/12-path-parameter-regex.generated.json
+++ b/convertoas3/oas3_testfiles/12-path-parameter-regex.generated.json
@@ -17,7 +17,7 @@
           ],
           "name": "path-parameter-test_opsid",
           "paths": [
-            "~/demo/(?\u003csomething\u003e[^#?/]+)/else/(?\u003ctodo\u003e[^#?/]+)/$"
+            "~/demo/(?\u003csomething\u003e[^#?/]+)/else/(?\u003cto_do\u003e[^#?/]+)/$"
           ],
           "plugins": [],
           "strip_path": false,

--- a/convertoas3/oas3_testfiles/12-path-parameter-regex.yaml
+++ b/convertoas3/oas3_testfiles/12-path-parameter-regex.yaml
@@ -9,7 +9,9 @@ servers:
   - url: "https://example.com"
 
 paths:
-  /demo/{something}/else/{todo}/:
+  # note that '-to-do' is not a valid regex capture name, hence it must be sanitized
+  # in the output.
+  /demo/{something}/else/{-to-do}/:
     get:
       operationId: opsid
       parameters:

--- a/convertoas3/oas3_testfiles/13-request-validator-plugin.expected.json
+++ b/convertoas3/oas3_testfiles/13-request-validator-plugin.expected.json
@@ -76,13 +76,13 @@
           ]
         },
         {
-          "id": "970623f5-d00f-5cd5-9071-b4bce41549a8",
+          "id": "6d4dfd63-5d87-5c9d-84dc-9e146b27e4fb",
           "methods": [
             "GET"
           ],
-          "name": "example_params-pathid_get",
+          "name": "example_params-path-id_get",
           "paths": [
-            "~/params/(?\u003cpathid\u003e[^#?/]+)/$"
+            "~/params/(?\u003cpath_id\u003e[^#?/]+)/$"
           ],
           "plugins": [
             {
@@ -116,7 +116,7 @@
                   {
                     "explode": false,
                     "in": "path",
-                    "name": "pathid",
+                    "name": "path_id",
                     "required": true,
                     "schema": "{\"type\":\"integer\"}",
                     "style": "simple"
@@ -125,7 +125,7 @@
                 "version": "draft4"
               },
               "enabled": true,
-              "id": "2e10f59b-08d4-5566-9330-dfe6fcb471f5",
+              "id": "98eedac8-4afc-5f2b-aaa2-d73a1297bca5",
               "name": "request-validator",
               "tags": [
                 "OAS3_import",

--- a/convertoas3/oas3_testfiles/13-request-validator-plugin.generated.json
+++ b/convertoas3/oas3_testfiles/13-request-validator-plugin.generated.json
@@ -76,13 +76,13 @@
           ]
         },
         {
-          "id": "970623f5-d00f-5cd5-9071-b4bce41549a8",
+          "id": "6d4dfd63-5d87-5c9d-84dc-9e146b27e4fb",
           "methods": [
             "GET"
           ],
-          "name": "example_params-pathid_get",
+          "name": "example_params-path-id_get",
           "paths": [
-            "~/params/(?\u003cpathid\u003e[^#?/]+)/$"
+            "~/params/(?\u003cpath_id\u003e[^#?/]+)/$"
           ],
           "plugins": [
             {
@@ -116,7 +116,7 @@
                   {
                     "explode": false,
                     "in": "path",
-                    "name": "pathid",
+                    "name": "path_id",
                     "required": true,
                     "schema": "{\"type\":\"integer\"}",
                     "style": "simple"
@@ -125,7 +125,7 @@
                 "version": "draft4"
               },
               "enabled": true,
-              "id": "2e10f59b-08d4-5566-9330-dfe6fcb471f5",
+              "id": "98eedac8-4afc-5f2b-aaa2-d73a1297bca5",
               "name": "request-validator",
               "tags": [
                 "OAS3_import",

--- a/convertoas3/oas3_testfiles/13-request-validator-plugin.yaml
+++ b/convertoas3/oas3_testfiles/13-request-validator-plugin.yaml
@@ -23,7 +23,7 @@ paths:
       responses:
         "200":
           description: OK
-  /params/{pathid}/:
+  /params/{path-id}/:
     get:
       x-kong-plugin-request-validator:
         enabled: true
@@ -46,7 +46,7 @@ paths:
             type: integer
           required: true
         - in: path
-          name: pathid
+          name: path_id
           schema:
             type: integer
           required: true

--- a/convertoas3/validator.go
+++ b/convertoas3/validator.go
@@ -54,7 +54,11 @@ func generateParameterSchema(operation *openapi3.Operation) *[]map[string]interf
 			paramConf := make(map[string]interface{})
 			paramConf["explode"] = explode
 			paramConf["in"] = paramValue.In
-			paramConf["name"] = paramValue.Name
+			if paramValue.In == "path" {
+				paramConf["name"] = sanitizeRegexCapture(paramValue.Name)
+			} else {
+				paramConf["name"] = paramValue.Name
+			}
 			paramConf["required"] = paramValue.Required
 			paramConf["style"] = getDefaultParamStyle(paramValue.Style, paramValue.In)
 

--- a/learnservice_oas.yaml
+++ b/learnservice_oas.yaml
@@ -220,7 +220,7 @@ paths:
                   "$ref": "#/components/schemas/LearningCenterTrack"
         '400':
           description: Bad Request
-  "/tracks/{id}":
+  "/tracks/{track-id}":
     delete:
       tags:
       - learn
@@ -231,7 +231,7 @@ paths:
         # TODO: validate security generated all together!!! report about it being broken
         # See #/components/securitySchemes for the definition
       parameters:
-      - name: id
+      - name: track-id
         in: path
         description: Id of the Track to delete
         required: true


### PR DESCRIPTION
This fixes [APIOPS-28](https://konghq.atlassian.net/browse/APIOPS-28), [FTI-3056](https://konghq.atlassian.net/browse/FTI-3056)

[APIOPS-28]: https://konghq.atlassian.net/browse/APIOPS-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FTI-3056]: https://konghq.atlassian.net/browse/FTI-3056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ