### PR TITLE
fix(oas) duplicate names based on final path slash

### DIFF
--- a/convertoas3/oas3.go
+++ b/convertoas3/oas3.go
@@ -539,9 +539,17 @@ func Convert(content *[]byte, opts O2kOptions) (map[string]interface{}, error) {
 			return nil, err
 		}
 		if pathBaseName == "" {
-			pathBaseName = path
+			pathBaseName = Slugify(path)
+			if strings.HasSuffix(path, "/") {
+				// a common case is 2 paths, one with and one without a trailing "/" so to prevent
+				// duplicate names being generated, we add a "~" suffix as a special case to cater
+				// for different names. Better user solution is to use operation-id's.
+				pathBaseName = pathBaseName + "~"
+			}
+		} else {
+			pathBaseName = Slugify(pathBaseName)
 		}
-		pathBaseName = docBaseName + "_" + Slugify(pathBaseName)
+		pathBaseName = docBaseName + "_" + pathBaseName
 
 		// Set up the defaults on the Path level
 		newPathService := false

--- a/convertoas3/oas3_testfiles/01-names-inferred.expected.json
+++ b/convertoas3/oas3_testfiles/01-names-inferred.expected.json
@@ -28,11 +28,11 @@
           ]
         },
         {
-          "id": "5e0d04cc-9c83-5ffd-817d-2230100812b0",
+          "id": "2ab3e49d-7565-5ac2-aaee-18d060e2e712",
           "methods": [
             "POST"
           ],
-          "name": "simple-api-overview__post",
+          "name": "simple-api-overview_~_post",
           "paths": [
             "~/$"
           ],

--- a/convertoas3/oas3_testfiles/13-request-validator-plugin.expected.json
+++ b/convertoas3/oas3_testfiles/13-request-validator-plugin.expected.json
@@ -84,7 +84,7 @@
           ],
           "name": "example_params-path-id_get",
           "paths": [
-            "~/params/(?\u003cpath_id\u003e[^#?/]+)/$"
+            "~/params/(?\u003cpath_id\u003e[^#?/]+)$"
           ],
           "plugins": [
             {

--- a/convertoas3/oas3_testfiles/13-request-validator-plugin.yaml
+++ b/convertoas3/oas3_testfiles/13-request-validator-plugin.yaml
@@ -23,7 +23,7 @@ paths:
       responses:
         "200":
           description: OK
-  /params/{path-id}/:
+  /params/{path-id}:
     get:
       x-kong-plugin-request-validator:
         enabled: true


### PR DESCRIPTION
A common case is to have 2 path, one with and one without a trailing slash. These were both genrated with the same name because the slash would be slugified-away. Now an extra "~" is added, since this is a very common case.

[FTI-4831](https://konghq.atlassian.net/browse/FTI-4831)

[FTI-4831]: https://konghq.atlassian.net/browse/FTI-4831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ